### PR TITLE
Fix #59. basePath substitution moved to APISettings

### DIFF
--- a/EmbeddedSocial/Sources/Generated/APIs.swift
+++ b/EmbeddedSocial/Sources/Generated/APIs.swift
@@ -6,19 +6,7 @@
 import Foundation
 
 open class EmbeddedSocialClientAPI {
-    private static var _basePath = "https://api.embeddedsocial.microsoft.com"
-    open static var basePath: String {
-        set {
-            _basePath = newValue
-        }
-        get {
-            if let path = getEnvironmentVariable("EmbeddedSocial_MOCK_SERVER") {
-                return path
-            } else {
-                return _basePath
-            }
-        }
-    }
+    open static var basePath = "https://api.embeddedsocial.microsoft.com"
     open static var credential: URLCredential?
     open static var customHeaders: [String:String] = [:]
     static var requestBuilderFactory: RequestBuilderFactory = AlamofireRequestBuilderFactory()

--- a/EmbeddedSocial/Sources/Model/APISettings.swift
+++ b/EmbeddedSocial/Sources/Model/APISettings.swift
@@ -11,7 +11,11 @@ final class APISettings {
     private let queue = DispatchQueue(label: "APISettings queue")
 
     private init() {
-        EmbeddedSocialClientAPI.basePath = Keys.ppeBasePath
+        if let path = getEnvironmentVariable("EmbeddedSocial_MOCK_SERVER") {
+            EmbeddedSocialClientAPI.basePath = path
+        } else {
+            EmbeddedSocialClientAPI.basePath = Keys.ppeBasePath
+        }
     }
     
     var anonymousHeaders: [String: String] {


### PR DESCRIPTION
Fix #59. basePath substitution moved to APISettings