### PR TITLE
#310 - add some helpful text and link to empty followers list - Added no data text for Followers, Following, Likes and Blocked lists.

### DIFF
--- a/EmbeddedSocial/Resources/Localizable.strings
+++ b/EmbeddedSocial/Resources/Localizable.strings
@@ -59,8 +59,10 @@
 "edit_profile.label.account_information" = "Account Information";
 
 "followers.screen_title" = "Followers";
+"followers.no_data_text" = "Currently nobody is following you.";
 
 "following.screen_title" = "Following";
+"following.no_data_text" = "Currently you are not following anyone.";
 
 "login.screen_title" = "Sign in";
 
@@ -123,6 +125,10 @@
 "popular_module.feed_option.all_time" = "All time";
 
 "likes_list.screen_title" = "Like this post";
+"likes_list.post.no_data_text" = "No one has liked this post yet.";
+"likes_list.comment.no_data_text" = "No one has liked this comment yet.";
+"likes_list.reply.no_data_text" = "No one has liked this reply yet.";
 
 "blocked_users.screen_title" = "Blocked users";
+"blocked_users.no_data_text" = "You haven't blocked anyone.";
 

--- a/EmbeddedSocial/Sources/Generated/SwiftGen/Strings.swift
+++ b/EmbeddedSocial/Sources/Generated/SwiftGen/Strings.swift
@@ -13,6 +13,8 @@ enum L10n {
   }
 
   enum BlockedUsers {
+    /// You haven't blocked anyone.
+    static let noDataText = L10n.tr("Localizable", "blocked_users.no_data_text")
     /// Blocked users
     static let screenTitle = L10n.tr("Localizable", "blocked_users.screen_title")
   }
@@ -133,11 +135,15 @@ enum L10n {
   }
 
   enum Followers {
+    /// Currently nobody is following you.
+    static let noDataText = L10n.tr("Localizable", "followers.no_data_text")
     /// Followers
     static let screenTitle = L10n.tr("Localizable", "followers.screen_title")
   }
 
   enum Following {
+    /// Currently you are not following anyone.
+    static let noDataText = L10n.tr("Localizable", "following.no_data_text")
     /// Following
     static let screenTitle = L10n.tr("Localizable", "following.screen_title")
   }
@@ -161,6 +167,21 @@ enum L10n {
   enum LikesList {
     /// Like this post
     static let screenTitle = L10n.tr("Localizable", "likes_list.screen_title")
+
+    enum Comment {
+      /// No one has liked this comment yet.
+      static let noDataText = L10n.tr("Localizable", "likes_list.comment.no_data_text")
+    }
+
+    enum Post {
+      /// No one has liked this post yet.
+      static let noDataText = L10n.tr("Localizable", "likes_list.post.no_data_text")
+    }
+
+    enum Reply {
+      /// No one has liked this reply yet.
+      static let noDataText = L10n.tr("Localizable", "likes_list.reply.no_data_text")
+    }
   }
 
   enum Login {
@@ -250,24 +271,24 @@ enum L10n {
     /// Report an issue
     static let screenTitle = L10n.tr("Localizable", "report.screen_title")
 
+    enum Comment {
+      /// What's the problem with this comment?
+      static let headerTitle = L10n.tr("Localizable", "report.comment.header_title")
+    }
+
     enum Post {
       /// What's the problem with this post?
       static let headerTitle = L10n.tr("Localizable", "report.post.header_title")
     }
 
+    enum Reply {
+      /// What's the problem with this reply?
+      static let headerTitle = L10n.tr("Localizable", "report.reply.header_title")
+    }
+
     enum User {
       /// What's the problem with this account?
       static let headerTitle = L10n.tr("Localizable", "report.user.header_title")
-    }
-    
-    enum Comment {
-        /// What's the problem with this comment?
-        static let headerTitle = L10n.tr("Localizable", "report.comment.header_title")
-    }
-    
-    enum Reply {
-        /// What's the problem with this reply?
-        static let headerTitle = L10n.tr("Localizable", "report.reply.header_title")
     }
   }
 

--- a/EmbeddedSocial/Sources/Modules/BlockedUsers/Configurator/BlockedUsersConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/BlockedUsers/Configurator/BlockedUsersConfigurator.swift
@@ -27,10 +27,15 @@ struct BlockedUsersConfigurator {
         
         let api = BlockedUsersAPI(socialService: SocialService())
         
+        let noDataText = NSAttributedString(string: L10n.BlockedUsers.noDataText,
+                                            attributes: [NSFontAttributeName: Fonts.medium,
+                                                         NSForegroundColorAttributeName: Palette.darkGrey])
+        
         let settings = UserListConfigurator.Settings(api: api,
                                                      navigationController: navigationController,
                                                      output: output,
-                                                     listItemsBuilder: BlockedUsersListItemsBuilder())
+                                                     listItemsBuilder: BlockedUsersListItemsBuilder(),
+                                                     noDataText: noDataText)
         
         return UserListConfigurator().configure(with: settings)
     }

--- a/EmbeddedSocial/Sources/Modules/Followers/Configurator/FollowersConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/Followers/Configurator/FollowersConfigurator.swift
@@ -29,9 +29,14 @@ final class FollowersConfigurator {
                                     navigationController: UINavigationController?,
                                     output: UserListModuleOutput?) -> UserListModuleInput {
         
+        let noDataText = NSAttributedString(string: L10n.Followers.noDataText,
+                                            attributes: [NSFontAttributeName: Fonts.medium,
+                                                         NSForegroundColorAttributeName: Palette.darkGrey])
+        
         let settings = UserListConfigurator.Settings(api: api,
                                                      navigationController: navigationController,
-                                                     output: output)
+                                                     output: output,
+                                                     noDataText: noDataText)
         
         return UserListConfigurator().configure(with: settings)
     }

--- a/EmbeddedSocial/Sources/Modules/Following/Configurator/FollowingConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/Following/Configurator/FollowingConfigurator.swift
@@ -29,9 +29,14 @@ final class FollowingConfigurator {
                                     navigationController: UINavigationController?,
                                     output: UserListModuleOutput?) -> UserListModuleInput {
         
+        let noDataText = NSAttributedString(string: L10n.Following.noDataText,
+                                            attributes: [NSFontAttributeName: Fonts.medium,
+                                                         NSForegroundColorAttributeName: Palette.darkGrey])
+        
         let settings = UserListConfigurator.Settings(api: api,
                                                      navigationController: navigationController,
-                                                     output: output)
+                                                     output: output,
+                                                     noDataText: noDataText)
         
         return UserListConfigurator().configure(with: settings)
     }

--- a/EmbeddedSocial/Sources/Modules/LikesList/Configurator/LikesListConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/LikesList/Configurator/LikesListConfigurator.swift
@@ -22,6 +22,7 @@ struct LikesListConfigurator {
         let api = LikesListAPI(handle: handle, type: type, likesService: LikesService())
 
         presenter.usersListModule = makeUserListModule(api: api,
+                                                       noDataText: type.noDataText,
                                                        navigationController: navigationController,
                                                        output: presenter)
         
@@ -29,12 +30,18 @@ struct LikesListConfigurator {
     }
     
     private func makeUserListModule(api: UsersListAPI,
+                                    noDataText: String,
                                     navigationController: UINavigationController?,
                                     output: UserListModuleOutput?) -> UserListModuleInput {
 
+        let noDataText = NSAttributedString(string: noDataText,
+                                            attributes: [NSFontAttributeName: Fonts.medium,
+                                                         NSForegroundColorAttributeName: Palette.darkGrey])
+        
         let settings = UserListConfigurator.Settings(api: api,
                                                      navigationController: navigationController,
-                                                     output: output)
+                                                     output: output,
+                                                     noDataText: noDataText)
         
         return UserListConfigurator().configure(with: settings)
     }

--- a/EmbeddedSocial/Sources/Modules/LikesList/Interactor/LikesListAPI.swift
+++ b/EmbeddedSocial/Sources/Modules/LikesList/Interactor/LikesListAPI.swift
@@ -9,6 +9,17 @@ enum LikedObject {
     case post
     case comment
     case reply
+    
+    var noDataText: String {
+        switch self {
+        case .post:
+            return L10n.LikesList.Post.noDataText
+        case .comment:
+            return L10n.LikesList.Comment.noDataText
+        case .reply:
+            return L10n.LikesList.Reply.noDataText
+        }
+    }
 }
 
 struct LikesListAPI: UsersListAPI {

--- a/EmbeddedSocial/Sources/Modules/SearchPeople/Configurator/SearchPeopleConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/SearchPeople/Configurator/SearchPeopleConfigurator.swift
@@ -17,12 +17,10 @@ final class SearchPeopleConfigurator {
         let interactor = SearchPeopleInteractor()
         
         let presenter = SearchPeoplePresenter()
-
-        let api = EmptyUsersListAPI()
-        let usersListModule = makeUserListModule(api: api, navigationController: navigationController, output: presenter)
         
         presenter.view = viewController
-        presenter.usersListModule = usersListModule
+        presenter.usersListModule = makeUserListModule(api: EmptyUsersListAPI(), noDataText: nil,
+                                                       navigationController: navigationController, output: presenter)
         presenter.interactor = interactor
         presenter.moduleOutput = output
         
@@ -36,20 +34,22 @@ final class SearchPeopleConfigurator {
         moduleInput = presenter
     }
     
+    private func makeBackgroundUsersListModule(navigationController: UINavigationController?,
+                                               output: UserListModuleOutput?) -> UserListModuleInput {
+        let api = SuggestedUsersAPI(socialService: SocialService())
+        return makeUserListModule(api: api, noDataText: nil, navigationController: navigationController, output: output)
+    }
+    
     private func makeUserListModule(api: UsersListAPI,
+                                    noDataText: NSAttributedString?,
                                     navigationController: UINavigationController?,
                                     output: UserListModuleOutput?) -> UserListModuleInput {
         
         let settings = UserListConfigurator.Settings(api: api,
                                                      navigationController: navigationController,
-                                                     output: output)
+                                                     output: output,
+                                                     noDataText: noDataText)
         
         return UserListConfigurator().configure(with: settings)
-    }
-    
-    private func makeBackgroundUsersListModule(navigationController: UINavigationController?,
-                                               output: UserListModuleOutput?) -> UserListModuleInput {
-        let api = SuggestedUsersAPI(socialService: SocialService())
-        return makeUserListModule(api: api, navigationController: navigationController, output: output)
     }
 }

--- a/EmbeddedSocial/Sources/Modules/SearchPeople/View/SearchPeopleViewController.swift
+++ b/EmbeddedSocial/Sources/Modules/SearchPeople/View/SearchPeopleViewController.swift
@@ -13,6 +13,7 @@ final class SearchPeopleViewController: UIViewController {
     @IBOutlet weak var noContentLabel: UILabel! {
         didSet {
             noContentLabel.isHidden = true
+            noContentLabel.textColor = Palette.darkGrey
         }
     }
     

--- a/EmbeddedSocial/Sources/Modules/SearchTopics/View/SearchTopicsViewController.swift
+++ b/EmbeddedSocial/Sources/Modules/SearchTopics/View/SearchTopicsViewController.swift
@@ -15,6 +15,7 @@ class SearchTopicsViewController: UIViewController {
     @IBOutlet weak var noContentLabel: UILabel! {
         didSet {
             noContentLabel.isHidden = true
+            noContentLabel.textColor = Palette.darkGrey
         }
     }
     

--- a/EmbeddedSocial/Sources/Modules/UserList/Configurator/UserListConfigurator.swift
+++ b/EmbeddedSocial/Sources/Modules/UserList/Configurator/UserListConfigurator.swift
@@ -18,7 +18,7 @@ struct UserListConfigurator {
         
         let interactor = UserListInteractor(api: settings.api, socialService: SocialService())
         
-        let presenter = UserListPresenter(myProfileHolder: settings.myProfileHolder)
+        let presenter = UserListPresenter(myProfileHolder: settings.myProfileHolder, noDataText: settings.noDataText)
         presenter.view = view
         presenter.moduleOutput = settings.output
         presenter.interactor = interactor
@@ -46,6 +46,7 @@ extension UserListConfigurator {
         var navigationController: UINavigationController?
         var output: UserListModuleOutput?
         var listItemsBuilder: UserListItemsBuilder
+        var noDataText: NSAttributedString?
         
         init(api: UsersListAPI,
              myProfileHolder: UserHolder = SocialPlus.shared,
@@ -53,7 +54,8 @@ extension UserListConfigurator {
              loginOpener: LoginModalOpener? = SocialPlus.shared.coordinator,
              navigationController: UINavigationController?,
              output: UserListModuleOutput?,
-             listItemsBuilder: UserListItemsBuilder = UserListItemsBuilder()) {
+             listItemsBuilder: UserListItemsBuilder = UserListItemsBuilder(),
+             noDataText: NSAttributedString? = nil) {
             
             self.api = api
             self.myProfileHolder = myProfileHolder
@@ -62,6 +64,7 @@ extension UserListConfigurator {
             self.navigationController = navigationController
             self.output = output
             self.listItemsBuilder = listItemsBuilder
+            self.noDataText = noDataText
         }
     }
 }

--- a/EmbeddedSocial/Sources/Modules/UserList/Presenter/UserListPresenter.swift
+++ b/EmbeddedSocial/Sources/Modules/UserList/Presenter/UserListPresenter.swift
@@ -12,12 +12,16 @@ class UserListPresenter {
     var router: UserListRouterInput!
     fileprivate let myProfileHolder: UserHolder
     fileprivate var isAnimatingPullToRefresh: Bool = false
+    fileprivate let noDataText: NSAttributedString?
     
-    init(myProfileHolder: UserHolder) {
+    init(myProfileHolder: UserHolder, noDataText: NSAttributedString?) {
         self.myProfileHolder = myProfileHolder
+        self.noDataText = noDataText
     }
     
     func loadNextPage() {
+        view.setNoDataText(nil)
+        
         interactor.getNextListPage { [weak self] result in
             self?.processUsersResult(result)
         }
@@ -30,6 +34,9 @@ class UserListPresenter {
         } else {
             moduleOutput?.didFailToLoadList(listView: listView, error: result.error ?? APIError.unknown)
         }
+        
+        let hasContent = result.value?.isEmpty == false
+        view.setNoDataText(hasContent ? noDataText : nil)
     }
 }
 
@@ -88,6 +95,8 @@ extension UserListPresenter: UserListViewOutput {
     
     func onPullToRefresh() {
         isAnimatingPullToRefresh = true
+        view.setNoDataText(nil)
+
         interactor.reloadList { [weak self] result in
             self?.isAnimatingPullToRefresh = false
             self?.view.endPullToRefreshAnimation()

--- a/EmbeddedSocial/Sources/Modules/UserList/View/UserListView.swift
+++ b/EmbeddedSocial/Sources/Modules/UserList/View/UserListView.swift
@@ -46,6 +46,12 @@ class UserListView: UIView {
         return refreshControl
     }()
     
+    fileprivate lazy var noDataLabel: UILabel = { [unowned self] in
+        let label = UILabel()
+        self.addSubview(label)
+        return label
+    }()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
     }
@@ -73,6 +79,12 @@ extension UserListView: UserListViewInput {
         tableView.snp.makeConstraints { make in
             make.edges.equalTo(self)
         }
+        
+        let navBarAndStatusBarHeight: CGFloat = 64
+        noDataLabel.snp.makeConstraints { make in
+            make.centerX.equalTo(self)
+            make.centerY.equalTo(self).offset(-navBarAndStatusBarHeight)
+        }
     }
     
     func setUsers(_ users: [User]) {
@@ -98,5 +110,9 @@ extension UserListView: UserListViewInput {
     
     func endPullToRefreshAnimation() {
         refreshControl.endRefreshing()
+    }
+    
+    func setNoDataText(_ text: NSAttributedString?) {
+        noDataLabel.attributedText = text
     }
 }

--- a/EmbeddedSocial/Sources/Modules/UserList/View/UserListViewInput.swift
+++ b/EmbeddedSocial/Sources/Modules/UserList/View/UserListViewInput.swift
@@ -21,4 +21,6 @@ protocol UserListViewInput: class {
     func removeUser(_ user: User)
     
     func endPullToRefreshAnimation()
+    
+    func setNoDataText(_ text: NSAttributedString?)
 }

--- a/EmbeddedSocialTests/Modules/UserList/Mocks/MockUserListView.swift
+++ b/EmbeddedSocialTests/Modules/UserList/Mocks/MockUserListView.swift
@@ -75,10 +75,20 @@ final class MockUserListView: UIView, UserListViewInput {
     }
     
     //MARK: - endPullToRefreshAnimation
-
+    
     var endPullToRefreshAnimationCalled = false
-
+    
     func endPullToRefreshAnimation() {
         endPullToRefreshAnimationCalled = true
+    }
+    
+    //MARK: - setNoDataText
+    
+    var setNoDataTextCalled = false
+    var setNoDataTextReceivedText: NSAttributedString?
+    
+    func setNoDataText(_ text: NSAttributedString?) {
+        setNoDataTextCalled = true
+        setNoDataTextReceivedText = text
     }
 }

--- a/EmbeddedSocialTests/Modules/UserList/UserListPresenterTests.swift
+++ b/EmbeddedSocialTests/Modules/UserList/UserListPresenterTests.swift
@@ -13,6 +13,7 @@ class UserListPresenterTests: XCTestCase {
     var router: MockUserListRouter!
     var myProfileHolder: MyProfileHolder!
     var sut: UserListPresenter!
+    var noDataText: NSAttributedString!
     
     private let timeout: TimeInterval = 5.0
     
@@ -23,8 +24,9 @@ class UserListPresenterTests: XCTestCase {
         moduleOutput = MockUserListModuleOutput()
         router = MockUserListRouter()
         myProfileHolder = MyProfileHolder()
+        noDataText = NSAttributedString(string: "No data text")
         
-        sut = UserListPresenter(myProfileHolder: myProfileHolder)
+        sut = UserListPresenter(myProfileHolder: myProfileHolder, noDataText: noDataText)
         sut.interactor = interactor
         sut.view = view
         sut.moduleOutput = moduleOutput
@@ -39,6 +41,7 @@ class UserListPresenterTests: XCTestCase {
         router = nil
         sut = nil
         myProfileHolder = nil
+        noDataText = nil
     }
     
     func testThatItSetsInitialState() {
@@ -306,5 +309,11 @@ class UserListPresenterTests: XCTestCase {
         XCTAssertEqual(interactor.getNextListPageCount, page)
         XCTAssertTrue(view.setUsersCalled)
         XCTAssertEqual(view.setUsersReceivedUsers ?? [], users)
+        XCTAssertTrue(view.setNoDataTextCalled)
+        if users.isEmpty {
+            XCTAssertNil(view.setNoDataTextReceivedText)
+        } else {
+            XCTAssertEqual(noDataText, view.setNoDataTextReceivedText)
+        }
     }
 }


### PR DESCRIPTION
https://github.com/Microsoft/MSR-SocialPlus-iOS-SDK/issues/310 partially implemented:
1. Added no data text for Followers, Following, Likes and Blocked lists.
2. Search People list has this feature already implemented: left it unchanged.
3. Updated UserList module tests.